### PR TITLE
Added command-line interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,11 @@ lazy_ips
 
 ips patcher for Linux
 
-Dependences: Python3 and pygtk3
+Dependencies: Python3 and pygtk3
+
+lazy_ips_cli
+============
+
+Command-line interface for IPS patching. Does not require pygtk3.
+
+Usage: ```lazy_ips_cli image_file patch_file```

--- a/lazy_ips.py
+++ b/lazy_ips.py
@@ -2,11 +2,12 @@
 # -*- coding: utf-8 -*-
 
 # Name: lazy_ips.py
-# Version (last modification): 2019.09.30
+# Version (last modification): 2019.11.22
 # License: GNU GPL v3
 # Original author: Boris Timofeev https://github.com/btimofeev
 # Port to Python 3: Hubert Figuière https://github.com/hfiguiere
 # Various fixes: https://github.com/hadess
+# Cleanup and CLI: https://github.com/rekentuig
 
 import os, shutil
 import gi

--- a/lazy_ips_cli.py
+++ b/lazy_ips_cli.py
@@ -1,0 +1,29 @@
+from patch_ips import read_ips_patch, apply_patch_line
+import argparse
+
+parser = argparse.ArgumentParser(description="Apply IPS patch to ROM image")
+parser.add_argument("image_file")
+parser.add_argument("patch_file")
+
+args = parser.parse_args()
+
+try:
+    image = open(args.image_file, 'rb+')
+except Exception as err:
+    print(f"Error opening {args.image_file}: {err}")
+    exit()
+
+try:
+    patch = open(args.patch_file, 'rb')
+except Exception as err:
+    print(f"Error opening {args.patch_file}: {err}")
+    exit()
+
+try:
+    for patch_line in read_ips_patch(patch):
+        apply_patch_line(image, patch_line)
+except Exception as err:
+    print(f"Error patching {args.image_file}: {err}")
+finally:
+    patch.close()
+    image.close()

--- a/lazy_ips_cli.py
+++ b/lazy_ips_cli.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from patch_ips import read_ips_patch, apply_patch_line
 import argparse
 

--- a/patch_ips.py
+++ b/patch_ips.py
@@ -1,0 +1,60 @@
+from collections import namedtuple
+from struct import unpack
+
+PatchLine = namedtuple('PatchLine', ['offset', 'data'])
+
+def read_ips_patch_line(file):
+    eof_marker = b'EOF'
+    offset_size = 3
+    data_len_size = 2
+    rle_len_size = 2
+
+    try:
+        offset_raw = file.read(offset_size)
+        if offset_raw == eof_marker:
+            return None
+        offset = unpack('>l', b'\x00' + offset_raw)[0]
+    
+    except:
+        raise IOError("error reading offset")
+
+    try:
+        data_len_raw = file.read(data_len_size)
+        data_len = unpack('>h', data_len_raw)[0]
+        
+        if data_len > 0:
+            data = file.read(data_len)
+            return PatchLine(offset, data)
+
+        # RLE
+        rle_len_raw = file.read(rle_len_size)
+        rle_len = unpack('>h', rle_len_raw)[0]
+        rle_byte = file.read(1)
+        data = rle_byte * rle_len
+        return PatchLine(offset, data)
+
+    except:
+        raise IOError("error reading data")
+
+def read_ips_patch(file):
+    patch_marker = b'PATCH'
+
+    # Check marker.
+    data = file.read(len(patch_marker))
+    if data != patch_marker:
+        raise IOError("unknown format")
+
+    eof = False
+    while not eof:
+        data = read_ips_patch_line(file)
+        if data:
+            yield data
+        else:
+            eof = True
+
+def apply_patch_line(image, patch_line):
+    try:
+        image.seek(patch_line.offset)
+    except:
+        image.seek(0, 2)
+    image.write(patch_line.data)


### PR DESCRIPTION
I needed a simple command-line tool for applying IPS patches on OSX, so I extracted the .IPS parsing code and the image writing code from lazy_ips.py to a separate file and added a simple CLI (lazy_ips_cli.py) that uses the same code. This way, people can use lazy_ips without necessarily installing GTK. Hope it's useful to some!
